### PR TITLE
change validation for string sets to use the string as a single element

### DIFF
--- a/stratosphere/resources.py
+++ b/stratosphere/resources.py
@@ -94,6 +94,11 @@ class BaseGCPResource(object):
                         self._raise_value(key, value, allowed_values)
             # allowed_values is a list. We want to make sure the value is a
             # subset of the allowed values.
+            
+            # if the incoming value is string, make a single-element set of that string instead of a set of chars in the string
+            elif isinstance(value, str) and not (set([value]) <= set(allowed_values)):
+                self._raise_value(key, value, allowed_values)
+            # else make a set of the incoming values and compare
             elif not (set(value) <= set(allowed_values)):
                 self._raise_value(key, value, allowed_values)
         if isinstance(expected_type, list):


### PR DESCRIPTION
Fix the set logic to allow a single string to be treated as a single element set of that string. Example of the logic, where `bad` is the current behavior, and `good` is the behavior after this fix:

```
>>> python3
Python 3.5.2 (default, Sep 28 2016, 18:08:09)
[GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.38)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> bad = set("foo")
>>> data = set(["foo", "bar", "baz"])
>>> bad <= data
False
>>> good = set(["foo"])
>>> good <= data
True
```

Ran into this when investigating the property definitions for the disk on a compute instance we have.  Setting the `disks` property of an `InstanceTemplateProperty` was failing when setting the diskType to a proper type, as below:

```
disks=[
    InstanceTemplateDisksProperty(
        boot=True,
        index=0,
        type=InstanceTemplateDisksProperty.PERSISTENT,
        initializeParams=InstanceTemplateDiskInitializeParamsProperty(
            sourceImage=get_latest_image('windows-cloud', 'windows-server-2012-r2-dc-v20160916'),
            # bad setting here
            diskType=InstanceTemplateDiskInitializeParamsProperty.SSD,
            diskSizeGb=pano_sticher_config['rootfs_size']
        ),
        autoDelete=True
    )
]
```
